### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
+## [0.6.0 UNRELEASED]
 
-## [0.4.1 UNRELEASED]
+## [0.5.0]
 ### Changed
 - Removed expose-test in `nifi.hcl` for service nifi-registry. #34
 - Refactored `on_pr_push_master.yml` (GitHub actions) with same structure as in `terraform-nomad-nifiregistry`. #34


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #62 
## What was added/changed/fixed?
## [0.5.0]
### Changed
- Removed expose-test in `nifi.hcl` for service nifi-registry. #34
- Refactored `on_pr_push_master.yml` (GitHub actions) with same structure as in `terraform-nomad-nifiregistry`. #34
- Added new step to run `make test-standalone` for example/standalone in `.github/workflows/on_pr_push_master.yml`  #42
- Deleted unused vault_secret variables  #57
### Added
- Create intentions from service-to-service: nifi=> nifi_registry (in Ansible playbook: /dev/Ansible) #53

## Related issue(s)? [Optional]

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [ ] Added to project
- [ ] Added to milestone